### PR TITLE
/profile endpoints

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,7 @@ use std::error::Error;
 fn main() -> Result<(), Box<dyn Error>> {
     let r = Client::new();
 
-    let profiles = r.get_system_profiles()?;
-    for p in profiles {
-        println!("{}", p.server)
-    }
+    println!("PROFILE: {:#?}", r.query_active_profiles()?);
 
     Ok(())
 }


### PR DESCRIPTION
`GET /profile` endpoint working 
* Doesn't retrieve **a** profile it retrieves a hash map of profiles currently active (ie no disconnected)

`POST /profile` endpoint working
* Connects to a profile (currently only supporting ovpn

`DEL /profile` endpoint working
* Disconnected a profile

NOTE: currently only one socket request can be made before the socket is closed. Am dealing with it in a further ticket