### PR TITLE
Fix closing socket after one request

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -36,6 +36,7 @@ pub struct Profile {
 pub struct Client {
     pub auth_key: String,
     pub prof_path: PathBuf,
+    pub socket_path: String,
     pub client: UnixStream,
     pub profiles: Vec<Profile>,
 }
@@ -44,12 +45,18 @@ impl Client {
     pub fn new() -> Self {
         let profile_path = get_profile_path().unwrap();
         let profiles = load_profiles(&profile_path);
+        let socket_path = "/var/run/pritunl.sock";
         Self {
             auth_key: get_auth_key().unwrap(),
             prof_path: profile_path,
-            client: UnixStream::connect("/var/run/pritunl.sock").unwrap(),
+            socket_path: String::from(socket_path),
+            client: UnixStream::connect(socket_path).unwrap(),
             profiles,
         }
+    }
+
+    pub fn new_socket_connection(&self) -> UnixStream {
+        UnixStream::connect(&self.socket_path).expect("Couldn't create unix socket")
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -37,7 +37,6 @@ pub struct Client {
     pub auth_key: String,
     pub prof_path: PathBuf,
     pub socket_path: String,
-    pub client: UnixStream,
     pub profiles: Vec<Profile>,
 }
 
@@ -45,12 +44,11 @@ impl Client {
     pub fn new() -> Self {
         let profile_path = get_profile_path().unwrap();
         let profiles = load_profiles(&profile_path);
-        let socket_path = "/var/run/pritunl.sock";
+        let socket_path = String::from("/var/run/pritunl.sock");
         Self {
             auth_key: get_auth_key().unwrap(),
             prof_path: profile_path,
-            socket_path: String::from(socket_path),
-            client: UnixStream::connect(socket_path).unwrap(),
+            socket_path: socket_path,
             profiles,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let r = Client::new();
 
     println!("PROFILE: {:#?}", r.query_active_profiles()?);
+    println!("PROFILE: {:#?}", r.query_active_profiles()?);
+    println!("PROFILE: {:#?}", r.query_active_profiles()?);
 
     Ok(())
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -57,11 +57,14 @@ fn format_request(r: &Client, endpoint: &str, method: RequestVerb, body: &str) -
 }
 
 fn send_request(r: &Client, req: String) -> Result<String, io::Error> {
-    let mut socket = &r.client;
-    socket.write_all(req.as_bytes())?;
+    // TODO: Socket was closing for write after read, find better solution
+    //  than new connection for each request
+    let mut socket_connection = r.new_socket_connection();
+
+    socket_connection.write_all(req.as_bytes())?;
 
     let mut res = String::new();
-    socket.read_to_string(&mut res)?;
+    socket_connection.read_to_string(&mut res)?;
 
     Ok(res)
 }
@@ -74,8 +77,8 @@ fn parse_response(res: String) -> Response {
     let success = headers[..].contains("200 OK");
 
     Response {
+        success,
         headers,
         body,
-        success,
     }
 }


### PR DESCRIPTION
Recreating a new unix socket connection each request avoids to issue of the socket closing after a read and a write have been performed. This is a quick fix to enable multi call functionality until the deeper issue is discovered and fixed in a better way.

Another solution that also worked without code changes was making a new client for each call. While creating a new socket connection for each call is similar, the client creation currently reads from disk to retrieve the pritunl authentication token so this avoided that read each call.

fixes #17 